### PR TITLE
Fix update credentials docs

### DIFF
--- a/services/auth-service/README.md
+++ b/services/auth-service/README.md
@@ -129,3 +129,25 @@ Content-Type: application/json
 ```json
 { "success": true, "message": "2FA disabled successfully." }
 ```
+
+### 7. PATCH /auth/update-credentials 🔐
+
+Allows a logged-in user to change their email and/or password.
+
+**Request**  
+```json
+{
+  "currentPassword": "1234",
+  "newEmail": "novo@email.com",
+  "newPassword": "abc123"
+}
+
+You can include either or both of newEmail and newPassword.
+```
+**Response 200**
+```json
+{
+  "success": true,
+  "message": "Credentials updated successfully."
+}
+```

--- a/services/match-service/README.md
+++ b/services/match-service/README.md
@@ -128,25 +128,3 @@ Authorization: Bearer <JWT>
   ]
 }
 ```
-
-### 6. PATCH /auth/update-credentials 🔐
-
-Allows a logged-in user to change their email and/or password.
-
-**Request**  
-```json
-{
-  "currentPassword": "1234",
-  "newEmail": "novo@email.com",
-  "newPassword": "abc123"
-}
-
-You can include either or both of newEmail and newPassword.
-```
-**Response 200**
-```json
-{
-  "success": true,
-  "message": "Credentials updated successfully."
-}
-```


### PR DESCRIPTION
## Summary
- remove `PATCH /auth/update-credentials` from match-service docs
- document `PATCH /auth/update-credentials` in auth-service docs where it belongs

## Testing
- `npm test` (fails: Missing script: test)

------
https://chatgpt.com/codex/tasks/task_e_68504c95f85c832bb64c6416021a159f