### PR TITLE
Fix multiplayer setup and shorter room IDs

### DIFF
--- a/frontend/src/views/game/core/MultiplayerManager.ts
+++ b/frontend/src/views/game/core/MultiplayerManager.ts
@@ -13,21 +13,21 @@ export class MultiplayerManager {
 
     constructor() {}
 
-    public setupMultiplayer(isHost: boolean, player1Name: string, onModeSelected: (mode: 'classic' | 'powerup') => void, onPlayerSide: (side: 'left' | 'right' | null) => void, onRoomId?: (roomId: string) => void): void {
+    public async setupMultiplayer(isHost: boolean, player1Name: string, onModeSelected: (mode: 'classic' | 'powerup') => void, onPlayerSide: (side: 'left' | 'right' | null) => void, onRoomId?: (roomId: string) => void): Promise<void> {
         this._player1Name = player1Name;
         this._modeSelectedCallback = onModeSelected;
         this._playerSideCallback = onPlayerSide;
         if (isHost) {
-            fetch('http://localhost:3004/create-room')
-                .then(response => response.json())
-                .then(data => {
-                    this._roomId = data.roomId;
-                    if (onRoomId) onRoomId(this._roomId);
-                    // UI para host escolher modo
-                })
-                .catch(error => {
-                    alert("Failed to create room. Check console for details.");
-                });
+            try {
+                const response = await fetch('http://localhost:3004/create-room');
+                const data = await response.json();
+                this._roomId = data.roomId;
+                if (onRoomId) onRoomId(this._roomId);
+                this.connectToGameServer();
+                // UI para host escolher modo
+            } catch (error) {
+                alert("Failed to create room. Check console for details.");
+            }
         } else {
             const roomId = prompt('Enter Room ID:');
             if (roomId) {

--- a/frontend/src/views/game/managers/GameManager.ts
+++ b/frontend/src/views/game/managers/GameManager.ts
@@ -95,15 +95,15 @@ export class GameManager {
                 console.log('[Multiplayer] Iniciar jogo com power-ups');
                 this._startGame(true);
             },
-            () => {
+            async () => {
                 console.log('[Multiplayer] Host: criar sala');
                 this._multiplayerManager.gameMode = GameMode.MULTIPLAYER_HOST;
-                this._setupMultiplayer(true);
+                await this._setupMultiplayer(true);
             },
-            () => {
+            async () => {
                 console.log('[Multiplayer] Join: entrar em sala');
                 this._multiplayerManager.gameMode = GameMode.MULTIPLAYER_JOIN;
-                this._setupMultiplayer(false);
+                await this._setupMultiplayer(false);
             }
         );
         this._gameOverUI = this._uiManager.createGameOverUI(
@@ -389,9 +389,9 @@ export class GameManager {
     }
     
     // Add a new method to handle multiplayer setup
-    private _setupMultiplayer(isHost: boolean): void {
+    private async _setupMultiplayer(isHost: boolean): Promise<void> {
         console.log(`[Multiplayer] Setup: isHost=${isHost}, player1Name=${this._player1Name}`);
-        this._multiplayerManager.setupMultiplayer(
+        await this._multiplayerManager.setupMultiplayer(
             isHost,
             this._player1Name,
             (mode) => {

--- a/services/game-service/src/index.js
+++ b/services/game-service/src/index.js
@@ -24,7 +24,7 @@ const gameRooms = new Map();
 
 // Simple endpoint to create game rooms
 fastify.get('/create-room', async () => {
-  const roomId = `room_${Date.now()}`;
+  const roomId = Math.random().toString(36).slice(2, 8);
   gameRooms.set(roomId, new GameRoom(roomId));
   return { roomId };
 });


### PR DESCRIPTION
## Summary
- generate shorter room IDs on game service
- automatically connect host to the created room
- make multiplayer setup callbacks async

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687836e339f4832b9fbf2f4839a8cf40