### PR TITLE
Implement simple lobby page and backend

### DIFF
--- a/frontend/src/router/Router.ts
+++ b/frontend/src/router/Router.ts
@@ -3,6 +3,7 @@ import { Builders } from "../views/Builders";
 
 const routes: {[key: string]: () => AView } = {
     "/game": Builders.GameBuilder,
+    "/lobby": Builders.LobbyBuilder,
     "/tournament": Builders.TournamentBuilder,
     "/login": Builders.LoginBuilder,
     "/register": Builders.RegisterBuilder,

--- a/frontend/src/views/Builders.ts
+++ b/frontend/src/views/Builders.ts
@@ -1,6 +1,7 @@
 import { Game } from "./game/Game";
 import { GameModeSelector } from "./game/GameModeSelector";
 import { Tournament } from "./tournament/Tournament";
+import { Lobby } from "./lobby/Lobby";
 import { Home } from "./home/Home";
 import { Login } from "./login/Login";
 import { Register } from "./register/Register";
@@ -26,6 +27,10 @@ export class Builders {
 
     public static TournamentBuilder(): AView {
         return new Tournament(); // Assuming Tournament is similar to Game for now
+    }
+
+    public static LobbyBuilder(): AView {
+        return new Lobby();
     }
 }
 

--- a/frontend/src/views/game/managers/NetworkManager.ts
+++ b/frontend/src/views/game/managers/NetworkManager.ts
@@ -13,6 +13,7 @@ export class NetworkManager {
     private _onGameEnd: ((data: any) => void) | null = null;
     private _onScore: ((data: any) => void) | null = null;
     private _onOpponentDisconnected: ((data: any) => void) | null = null;
+    private _onLobbyUpdate: ((data: any) => void) | null = null;
     private _onError: ((error: string) => void) | null = null;
     
     // Network optimization
@@ -98,6 +99,34 @@ export class NetworkManager {
         });
     }
 
+    public createLobby(): void {
+        if (!this._connected || !this._playerId || !this._playerName) return;
+        this._send({
+            type: 'create_lobby',
+            playerId: this._playerId,
+            playerName: this._playerName
+        });
+    }
+
+    public joinLobby(lobbyId: string): void {
+        if (!this._connected || !this._playerId || !this._playerName) return;
+        this._send({
+            type: 'join_lobby',
+            lobbyId: lobbyId,
+            playerId: this._playerId,
+            playerName: this._playerName
+        });
+    }
+
+    public startGame(lobbyId: string): void {
+        if (!this._connected || !this._playerId) return;
+        this._send({
+            type: 'start_game',
+            lobbyId: lobbyId,
+            playerId: this._playerId
+        });
+    }
+
     public sendInput(action: string): void {
         if (!this._connected || !this._playerId || !this._gameId) return;
 
@@ -140,6 +169,10 @@ export class NetworkManager {
 
     public onOpponentDisconnected(callback: (data: any) => void): void {
         this._onOpponentDisconnected = callback;
+    }
+
+    public onLobbyUpdate(callback: (data: any) => void): void {
+        this._onLobbyUpdate = callback;
     }
 
     public onError(callback: (error: string) => void): void {
@@ -231,6 +264,12 @@ export class NetworkManager {
 
                 case 'queue_left':
                     console.log('Left queue:', data.message);
+                    break;
+
+                case 'lobby_update':
+                    if (this._onLobbyUpdate) {
+                        this._onLobbyUpdate(data);
+                    }
                     break;
 
                 case 'pong':

--- a/frontend/src/views/lobby/Lobby.ts
+++ b/frontend/src/views/lobby/Lobby.ts
@@ -1,0 +1,118 @@
+import { AView } from "../AView";
+import { NetworkManager } from "../game/managers/NetworkManager";
+import { Game } from "../game/Game";
+
+export class Lobby extends AView {
+    private _network: NetworkManager;
+    private _players: { id: string; name: string }[] = [];
+    private _lobbyId: string | null = null;
+    private _playerId: string;
+    private _playerName: string;
+    private _isHost: boolean = false;
+    private _container: HTMLDivElement | null = null;
+
+    constructor() {
+        super();
+        this._network = new NetworkManager();
+        this._playerId = 'player_' + Math.random().toString(36).substr(2, 9) + '_' + Date.now();
+        this._playerName = prompt('Enter your name:') || 'Player';
+    }
+
+    public async render() {
+        const params = new URLSearchParams(window.location.search);
+        this._lobbyId = params.get('lobby');
+
+        await this._network.connect(this._playerId, this._playerName);
+        this._setupHandlers();
+
+        if (this._lobbyId) {
+            this._isHost = false;
+            this._network.joinLobby(this._lobbyId);
+        } else {
+            this._isHost = true;
+            this._network.createLobby();
+        }
+
+        this._renderUI();
+    }
+
+    private _setupHandlers() {
+        this._network.onLobbyUpdate((data) => {
+            this._lobbyId = data.lobbyId;
+            this._players = data.players;
+            this._updateList();
+        });
+
+        this._network.onGameStart((data) => {
+            this.dispose();
+            const game = new Game('remote', this._playerId, this._playerName, () => {});
+            game.render();
+        });
+    }
+
+    private _renderUI() {
+        this._container = document.createElement('div');
+        this._container.className = 'flex flex-col items-center justify-center h-screen bg-gray-100';
+
+        const title = document.createElement('h2');
+        title.className = 'text-2xl font-bold mb-4';
+        title.textContent = 'Lobby';
+        this._container.appendChild(title);
+
+        const code = document.createElement('div');
+        code.className = 'mb-4 text-gray-700';
+        code.id = 'lobbyCode';
+        code.textContent = 'Code: ...';
+        this._container.appendChild(code);
+
+        const list = document.createElement('ul');
+        list.id = 'playersList';
+        list.className = 'mb-4';
+        this._container.appendChild(list);
+
+        const startBtn = document.createElement('button');
+        startBtn.textContent = 'Iniciar Partida';
+        startBtn.className = 'px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700';
+        startBtn.onclick = () => {
+            if (this._lobbyId) {
+                this._network.startGame(this._lobbyId);
+            }
+        };
+        startBtn.id = 'startBtn';
+        this._container.appendChild(startBtn);
+
+        document.body.appendChild(this._container);
+        this._updateList();
+    }
+
+    private _updateList() {
+        if (!this._container) return;
+        const codeDiv = this._container.querySelector('#lobbyCode') as HTMLDivElement;
+        if (codeDiv && this._lobbyId) {
+            codeDiv.textContent = `Code: ${this._lobbyId}`;
+        }
+
+        const list = this._container.querySelector('#playersList') as HTMLUListElement;
+        if (list) {
+            list.innerHTML = '';
+            this._players.forEach(p => {
+                const li = document.createElement('li');
+                li.textContent = p.name;
+                li.className = 'text-gray-800';
+                list.appendChild(li);
+            });
+        }
+
+        const startBtn = this._container.querySelector('#startBtn') as HTMLButtonElement;
+        if (startBtn) {
+            startBtn.style.display = this._isHost ? 'block' : 'none';
+        }
+    }
+
+    public dispose() {
+        if (this._container && this._container.parentNode) {
+            this._container.parentNode.removeChild(this._container);
+        }
+        this._network.disconnect();
+    }
+}

--- a/services/game-service/src/managers/LobbyManager.js
+++ b/services/game-service/src/managers/LobbyManager.js
@@ -1,0 +1,44 @@
+export class LobbyManager {
+    constructor() {
+        this.lobbies = new Map(); // lobbyId -> lobby object
+        this.counter = 0;
+    }
+
+    createLobby(host) {
+        this.counter++;
+        const lobbyId = `lobby_${this.counter}_${Date.now()}`;
+        const lobby = {
+            id: lobbyId,
+            hostId: host.id,
+            players: new Map([[host.id, host]])
+        };
+        host.lobbyId = lobbyId;
+        this.lobbies.set(lobbyId, lobby);
+        return lobby;
+    }
+
+    joinLobby(lobbyId, player) {
+        const lobby = this.lobbies.get(lobbyId);
+        if (!lobby) return null;
+        lobby.players.set(player.id, player);
+        player.lobbyId = lobbyId;
+        return lobby;
+    }
+
+    removePlayer(lobbyId, playerId) {
+        const lobby = this.lobbies.get(lobbyId);
+        if (!lobby) return;
+        lobby.players.delete(playerId);
+        if (lobby.players.size === 0) {
+            this.lobbies.delete(lobbyId);
+        }
+    }
+
+    getLobby(lobbyId) {
+        return this.lobbies.get(lobbyId);
+    }
+
+    removeLobby(lobbyId) {
+        this.lobbies.delete(lobbyId);
+    }
+}


### PR DESCRIPTION
## Summary
- support lobby creation in backend via `create_lobby`, `join_lobby`, `start_game`
- add `LobbyManager` to keep lobby state
- update WebSocket handling for lobby flow
- extend `NetworkManager` with lobby helpers
- create new `Lobby` view and register route

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bb733478832b9ea2a3ed1c8935e6